### PR TITLE
Feat: patch layers

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -28,6 +28,15 @@
           "method": "POST",
           "path": "/api/v1/contextual-layer/team/:teamId"
         }
+      },
+      {
+        "path": "/v1/contextual-layer/:layerId",
+        "method": "PATCH",
+        "authenticated": true,
+        "redirect": {
+          "method": "PATCH",
+          "path": "/api/v1/contextual-layer/:layerId"
+        }
       }
     ]
 }

--- a/app/src/models/layer.model.js
+++ b/app/src/models/layer.model.js
@@ -10,7 +10,7 @@ const Layer = new Schema({
     id: { type: Schema.Types.ObjectId, required: true, trim: true },
     type: { type: String, required: true, trim: true }
     },
-  disabled: { type: Boolean, required: true, default: false },
+  enabled: { type: Boolean, required: true, default: false },
   createdAt: { type: Date, required: true, default: Date.now }
 });
 

--- a/app/src/models/layer.model.js
+++ b/app/src/models/layer.model.js
@@ -10,6 +10,7 @@ const Layer = new Schema({
     id: { type: Schema.Types.ObjectId, required: true, trim: true },
     type: { type: String, required: true, trim: true }
     },
+  disabled: { type: Boolean, required: true, default: false },
   createdAt: { type: Date, required: true, default: Date.now }
 });
 

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -102,13 +102,19 @@ class Layer {
         team = await TeamService.getTeam(layer.owner.id);
       } catch (e) {
         logger.error(e);
-        ctx.throw(500, 'Team retrieval failed');
+        ctx.throw(500, 'Team retrieval failed.');
       }
     }
     const enabled = LayerService.getEnabled(layer, body, team);
     const isPublic = LayerService.updateIsPublic(layer, body);
     layer = Object.assign(layer, body, { isPublic, enabled });
-    await layer.save();
+    try {
+      await layer.save();
+    } catch (e) {
+      logger.error(e);
+      ctx.throw(500, 'Layer update failed.');
+    }
+
     ctx.body = LayerSerializer.serialize(layer);
   }
 }

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -90,7 +90,7 @@ class Layer {
     const body = ctx.request.body;
     let layer = null;
     try {
-      layer = await LayerModel.findOne({ id: layerId });
+      layer = await LayerModel.findOne({ _id: layerId });
       if (!layer) ctx.throw(404, 'Layer not found');
     } catch (e) {
       logger.error(e);
@@ -105,11 +105,11 @@ class Layer {
         ctx.throw(500, 'Team retrieval failed');
       }
     }
-    const disabled = LayerService.getDisabled(body, team);
+    const enabled = LayerService.getEnabled(layer, body, team);
     const isPublic = LayerService.updateIsPublic(layer, body);
-    layer = Object.assign(layer, body, { isPublic, disabled });
+    layer = Object.assign(layer, body, { isPublic, enabled });
     await layer.save();
-    ctx.body = LayerSerializer(layer);
+    ctx.body = LayerSerializer.serialize(layer);
   }
 }
 

--- a/app/src/serializers/layer.serializer.js
+++ b/app/src/serializers/layer.serializer.js
@@ -2,7 +2,7 @@ const logger = require('logger');
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
 
 const layerSerializer = new JSONAPISerializer('contextual-layer', {
-  attributes: ['isPublic', 'name', 'url', 'style', 'owner', 'createdAt'],
+  attributes: ['isPublic', 'name', 'url', 'style', 'disabled', 'owner', 'createdAt'],
   resource: {
     attributes: ['type', 'content']
   },

--- a/app/src/serializers/layer.serializer.js
+++ b/app/src/serializers/layer.serializer.js
@@ -2,7 +2,7 @@ const logger = require('logger');
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
 
 const layerSerializer = new JSONAPISerializer('contextual-layer', {
-  attributes: ['isPublic', 'name', 'url', 'style', 'disabled', 'owner', 'createdAt'],
+  attributes: ['isPublic', 'name', 'url', 'style', 'enabled', 'owner', 'createdAt'],
   resource: {
     attributes: ['type', 'content']
   },

--- a/app/src/services/layer.service.js
+++ b/app/src/services/layer.service.js
@@ -9,8 +9,20 @@ class LayerService {
     };
   }
 
+  static setIsPublic(data, owner) {
+    return (data.user.role === 'ADMIN') && (owner.type === LayerService.type.USER) ? data.isPublic : false;
+  }
+
+  static updateIsPublic(layer, data) {
+    return (data.user.role === 'ADMIN') && (layer.owner.type === LayerService.type.USER) ? data.isPublic : layer.isPublic;
+  }
+
+  static getDisabled(data, team) {
+    return !team || team.managers.includes(data.user.id) ? data.isPublic : data.disabled;
+  }
+
   static create(data, owner) {
-    const isPublic = (data.user.role === 'ADMIN') && (owner.type === 'USER') ? data.isPublic : false;
+    const isPublic = LayerService.setIsPublic(data, owner);
     const body = Object.assign({}, data, { isPublic, owner });
     return new LayerModel(body).save();
   }

--- a/app/src/services/layer.service.js
+++ b/app/src/services/layer.service.js
@@ -17,8 +17,8 @@ class LayerService {
     return (data.user.role === 'ADMIN') && (layer.owner.type === LayerService.type.USER) ? data.isPublic : layer.isPublic;
   }
 
-  static getDisabled(data, team) {
-    return !team || team.managers.includes(data.user.id) ? data.isPublic : data.disabled;
+  static getEnabled(layer, data, team) {
+    return (!team || team.managers.includes(data.user.id)) ? data.enabled : layer.enabled;
   }
 
   static create(data, owner) {

--- a/app/src/validators/layer.validator.js
+++ b/app/src/validators/layer.validator.js
@@ -7,8 +7,24 @@ class LayerValidator {
     ctx.checkBody('name').notEmpty().len(1, 200);
     ctx.checkBody('url').notEmpty().isUrl();
     ctx.checkBody('style').optional().notEmpty();
-    ctx.checkBody('isPublic').optional();
-    ctx.checkBody('disabled').optional().isBoolean();
+    ctx.checkBody('isPublic').optional().notEmpty();
+    ctx.checkBody('enabled').optional().notEmpty();
+
+    if (ctx.errors) {
+      ctx.body = ErrorSerializer.serializeValidationBodyErrors(ctx.errors);
+      ctx.status = 400;
+      return;
+    }
+    await next();
+  }
+
+  static async patch(ctx, next) {
+    logger.debug('Validating body for create team');
+    ctx.checkBody('name').optional().notEmpty().len(1, 200);
+    ctx.checkBody('url').optional().notEmpty().isUrl();
+    ctx.checkBody('style').optional().notEmpty();
+    ctx.checkBody('isPublic').optional().notEmpty();
+    ctx.checkBody('enabled').optional().notEmpty();
 
     if (ctx.errors) {
       ctx.body = ErrorSerializer.serializeValidationBodyErrors(ctx.errors);

--- a/app/src/validators/layer.validator.js
+++ b/app/src/validators/layer.validator.js
@@ -8,6 +8,7 @@ class LayerValidator {
     ctx.checkBody('url').notEmpty().isUrl();
     ctx.checkBody('style').optional().notEmpty();
     ctx.checkBody('isPublic').optional();
+    ctx.checkBody('disabled').optional().isBoolean();
 
     if (ctx.errors) {
       ctx.body = ErrorSerializer.serializeValidationBodyErrors(ctx.errors);


### PR DESCRIPTION
This PR includes the following:
- New endpoint PATCH `/contextual-layer/:layerId`.
    - Users can edit all fields of their user layers, with the exception of the _isPublic_ field. (Only Admins.)
    - Users can edit all fields of the team layers where they are managers, expect _isPublic_ field. (Only Admins.)
- Adds new field `enabled` to the model, this field lets the user show/hide layers.