### PR TITLE
feat: adds enabled query param to getAll

### DIFF
--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -21,6 +21,9 @@ class Layer {
   static async getAll(ctx) {
     logger.info('Get all layers');
     const userId = ctx.request.body.user.id;
+    const enabled = typeof ctx.request.query.enabled !== 'undefined' ?
+      { enabled: !!JSON.parse(ctx.request.query.enabled) }
+      : null;
     let team = null;
     try {
       team = await TeamService.getTeamByUserId(userId);
@@ -29,13 +32,19 @@ class Layer {
       ctx.throw(500, 'Error while retrieving user team');
     }
     const teamLayers = team && Array.isArray(team.layers) ? team.layers : [];
-    const layers = await LayerModel.find({
-        $or: [
-          { isPublic: true },
-          { 'owner.id': userId },
-          { id: { $in: teamLayers } }
-        ]
-    }, { owner: 0 });
+    const query = {
+      $and: [
+        {
+          $or: [
+            { isPublic: true },
+            { 'owner.id': userId },
+            { id: { $in: teamLayers } }
+          ]
+        }
+      ]
+    };
+    if (enabled) query.$and.push(enabled);
+    const layers = await LayerModel.find(query, { owner: 0 });
 
     ctx.body = LayerSerializer.serialize(layers);
   }

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -22,7 +22,7 @@ class Layer {
     logger.info('Get all layers');
     const userId = ctx.request.body.user.id;
     const enabled = typeof ctx.request.query.enabled !== 'undefined' ?
-      { enabled: !!JSON.parse(ctx.request.query.enabled) }
+      { enabled: ctx.request.query.enabled }
       : null;
     let team = null;
     try {
@@ -128,7 +128,7 @@ class Layer {
   }
 }
 
-router.get('/', ...Layer.middleware, Layer.getAll);
+router.get('/', ...Layer.middleware, LayerValidator.getAll, Layer.getAll);
 router.post('/', ...Layer.middleware, LayerValidator.create,  Layer.createUserLayer);
 router.patch('/:layerId', ...Layer.middleware, LayerValidator.patch, Layer.patchLayer);
 router.post('/team/:teamId', ...Layer.middleware, LayerValidator.create, Layer.createTeamLayer);

--- a/app/src/validators/layer.validator.js
+++ b/app/src/validators/layer.validator.js
@@ -2,8 +2,19 @@ const logger = require('logger');
 const ErrorSerializer = require('serializers/error.serializer');
 
 class LayerValidator {
+
+  static async getAll(ctx, next) {
+    ctx.checkQuery('enabled').optional().toBoolean();
+
+    if (ctx.errors) {
+      ctx.body = ErrorSerializer.serializeValidationBodyErrors(ctx.errors);
+      ctx.status = 400;
+      return;
+    }
+    await next();
+  }
+
   static async create(ctx, next) {
-    logger.debug('Validating body for create team');
     ctx.checkBody('name').notEmpty().len(1, 200);
     ctx.checkBody('url').notEmpty().isUrl();
     ctx.checkBody('style').optional().notEmpty();
@@ -19,7 +30,6 @@ class LayerValidator {
   }
 
   static async patch(ctx, next) {
-    logger.debug('Validating body for create team');
     ctx.checkBody('name').optional().notEmpty().len(1, 200);
     ctx.checkBody('url').optional().notEmpty().isUrl();
     ctx.checkBody('style').optional().notEmpty();


### PR DESCRIPTION
This PR lets the user request all his layers filtering by the `enabled` field:
- `/contextual-layer` => returns all user layers.
- `/contextual-layer/?enabled=true` => returns only the layers that are enabled.
- `/contextual-layer/?enabled=false` => returns only the layers that are not enabled.