### PR TITLE
Add tcl2019 contextual layer

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -14,5 +14,5 @@
     "host": "localhost",
     "port": "27017"
   },
-  "hansenUrl": "https://storage.googleapis.com/wri-public/Hansen19/tiles/hansen_world/v1/tc30/{z}/{x}/{y}.png"
+  "hansenUrl": "https://tiles.globalforestwatch.org/umd_tree_cover_loss/v1.7/tcd_30/{z}/{x}/{y}.png"
 }


### PR DESCRIPTION
Looks like https://storage.googleapis.com/wri-public/Hansen19/tiles/hansen_world/v1/tc30/{z}/{x}/{y}.png url doesn't work anymore. GFW references https://tiles.globalforestwatch.org/umd_tree_cover_loss/v1.7/tcd_30/{z}/{x}/{y}.png.
Let's switch to that one. I looked in the code and it substitutes only {z}, {x} and {y} and doesn't seem to rely on the base url structure.