### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -11,6 +11,7 @@ services:
       CT_REGISTER_MODE: auto
       CT_URL: http://mymachine:9000
       LOCAL_URL: http://mymachine:3025
+      MONGO_PORT_27017_TCP_ADDR: mongo
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       FASTLY_ENABLED: "false"
@@ -24,7 +25,7 @@ services:
     container_name: fw-contextual-layer-mongo-develop
     command: --smallfiles
     ports:
-      - "27017"
+      - "27023:27017"
     volumes:
       - $HOME/docker/data/fw-contextual-layer:/data/db
     restart: always


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Fix the mongo connection which was failing
- Allow external connections to mongo for local development 